### PR TITLE
remove unused dependency arm/Darwin64.amd from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@auth0/auth0-react": "^2.2.0",
-        "@esbuild/darwin-arm64": "^0.19.2",
         "@faker-js/faker": "^8.0.2",
         "@radix-ui/react-dialog": "^1.0.4",
         "@radix-ui/react-dropdown-menu": "^2.0.5",
@@ -164,20 +163,6 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.2.tgz",
-      "integrity": "sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==",
-      "cpu": [
-        "arm64"
-      ],
-      "os": [
-        "darwin"
       ],
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@auth0/auth0-react": "^2.2.0",
-    "@esbuild/darwin-arm64": "^0.19.2",
     "@faker-js/faker": "^8.0.2",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-dropdown-menu": "^2.0.5",


### PR DESCRIPTION
remove unused dependency arm/Darwin64.amd from package.json
Co-Authored: @danykdev, @dm2800, @YahyaT95, @kbulau 