### PR TITLE
add missing table names from QueryTimes charts

### DIFF
--- a/src/components/charts/QueryTimes.tsx
+++ b/src/components/charts/QueryTimes.tsx
@@ -115,7 +115,7 @@ export const QueryTimes: React.FC<BarGraphProps> = ({ table, tableName }) => {
       },
       title: {
         display: true,
-        text: 'Planning Execution Times',
+        text: `Planning Execution Times - ${tableName}`,
         color: '#17012866',
         font: {
           size: 14


### PR DESCRIPTION
add back in missing table names from Query Times charts. (appear to have been removed during renaming of chart titles and styling).